### PR TITLE
Bump version to 0.3.3 in pyproject.toml

### DIFF
--- a/packages/django-djazztro/pyproject.toml
+++ b/packages/django-djazztro/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "django-djazztro"
-version = "0.3.2"
+version = "0.3.3"
 description = "Python-side of the Djazztro stack, provides a template backend for using Astro files."
 authors = ["Ben C <bwc9876@gmail.com>"]
 packages = [{include = "django_djazztro"}]


### PR DESCRIPTION
This pull request includes a version update for the `django-djazztro` package. 

* [`packages/django-djazztro/pyproject.toml`](diffhunk://#diff-c92eba3ee81c47ad02ecced9db5308e5781005b3330f4f20043de370841fa919L3-R3): Updated the version from `0.3.2` to `0.3.3`.